### PR TITLE
Fix layout on mobile/narrow screens

### DIFF
--- a/src/scss/custom/_bar.scss
+++ b/src/scss/custom/_bar.scss
@@ -13,6 +13,7 @@
     .status-row {
         display: flex;
         margin-bottom: 2em;
+        width: 100%;
 
         .bar {
             flex-grow: 1;


### PR DESCRIPTION
Make the status graph take the whole line, irrespective of the label and availability fields.
Fixes the layout of the bar graph.

Closes #3 